### PR TITLE
Allow object literal for argument 'src'.

### DIFF
--- a/lib/merge.js
+++ b/lib/merge.js
@@ -78,14 +78,18 @@ function combine(dst, src) {
 
 /**
  * [merge description]
- * @param {String} dst [description]
- * @param {String|Object} src [description]
+ * @param {String|Buffer} dst [description]
+ * @param {String|Buffer|Object} src [description]
  * @returns {String} Result of merging src into dst.
  */
 function merge(dst, src) {
+	if (!isString(dst)) {
+		dst = dst.toString();
+	}
 	if (isString(src) || isBuffer(src)) {
 		src = json.parse(src.toString());
 	}
+
 	return json.update(dst, combine(json.parse(dst), src), { });
 }
 

--- a/lib/merge.js
+++ b/lib/merge.js
@@ -8,6 +8,8 @@ var isEmpty = require('lodash/lang/isEmpty');
 var filter = require('lodash/collection/filter');
 var contains = require('lodash/collection/contains');
 var has = require('lodash/object/has');
+var isBuffer = require('buffer').Buffer.isBuffer;
+var isString = require('util').isString;
 
 var handlers = {
 
@@ -77,11 +79,14 @@ function combine(dst, src) {
 /**
  * [merge description]
  * @param {String} dst [description]
- * @param {String} src [description]
+ * @param {String|Object} src [description]
  * @returns {String} Result of merging src into dst.
  */
 function merge(dst, src) {
-	return json.update(dst, combine(json.parse(dst), json.parse(src)), { });
+	if (isString(src) || isBuffer(src)) {
+		src = json.parse(src.toString());
+	}
+	return json.update(dst, combine(json.parse(dst), src), { });
 }
 
 module.exports = merge;

--- a/lib/merge.js
+++ b/lib/merge.js
@@ -4,12 +4,12 @@ var intersect = require('semver-set').intersect;
 var json = require('jju');
 var mapValues = require('lodash/object/mapValues');
 var assign = require('lodash/object/assign');
+var isBuffer = require('buffer').Buffer.isBuffer;
 var isEmpty = require('lodash/lang/isEmpty');
+var isString = require('lodash/lang/isString');
 var filter = require('lodash/collection/filter');
 var contains = require('lodash/collection/contains');
 var has = require('lodash/object/has');
-var isBuffer = require('buffer').Buffer.isBuffer;
-var isString = require('util').isString;
 
 var handlers = {
 

--- a/test/spec/merge.spec.js
+++ b/test/spec/merge.spec.js
@@ -39,4 +39,14 @@ describe('#merge', function() {
 
 		expect(result.dependencies).to.have.property('express', '^5.0.0');
 	});
+
+	it('should accept object literal for argument "src"', function() {
+		var result = JSON.parse(merge(
+			fixture('complete'),
+			{ dependencies: { foo: '^42.0.0' } }
+		));
+
+		expect(result.dependencies).to.have.property('foo', '^42.0.0');
+	});
+
 });


### PR DESCRIPTION
Hey!

I have created a pull request which aims to introduce this functionality which includes a simple unit test allowing for the following use case:

``` javascript
var merge = require('package-merge');
var dst = fs.readFileSync('package.a.json');
var src = fs.readFileSync('package.b.json');

// Create a new `package.json` 
console.log(merge(dst, {
    // Just merge the dependencies!
    dependencies: src.dependencies
}));
```

Since the usage example in the documentation demonstrates how to use this module with a `Buffer` (i.e. since no text encoding is specified):

> ``` javascript
> var merge = require('package-merge');
> var dst = fs.readFileSync('package.a.json');
> var src = fs.readFileSync('package.b.json');
> 
> // Create a new `package.json`
> console.log(merge(dst, src));
> ```

I have amended the `@param` tag in the doclet for consistency.

I also added an explicit conversion with `.toString()` to safeguard against internal changes in the jju dependency since the [jju](https://www.npmjs.com/package/jju#jjuparse-function) documentation does not expressly mention support for a `Buffer` argument.

I hope that you or others find this change useful.

Please let me know if you have any questions, thoughts, etc. :)

Many thanks!
