### PR TITLE
Sort dependency keys.

### DIFF
--- a/lib/merge.js
+++ b/lib/merge.js
@@ -81,7 +81,8 @@ function combine(dst, src) {
  * @returns {String} Result of merging src into dst.
  */
 function merge(dst, src) {
-	return json.update(dst, combine(json.parse(dst), json.parse(src)), { });
+	return json.stringify(combine(JSON.parse(dst), JSON.parse(src)),
+		assign(json.analyze(src), {no_trailing_comma: true, sort_keys: true}));
 }
 
 module.exports = merge;

--- a/test/spec/merge.spec.js
+++ b/test/spec/merge.spec.js
@@ -31,6 +31,25 @@ describe('#merge', function() {
 		expect(result.dependencies).to.have.property('express', '^5.0.0');
 	});
 
+	it('should maintain order of dependency packages', function () {
+		var result = merge(
+			fixture('complete'),
+			fixture('dependencies')
+		);
+		var dependencySection = result.match(/\"dependencies\": \{([\s\S]*?)\}/m)[1];
+		var dependencyNames = dependencySection.split("\n")
+			.filter(function (line) {
+				return line.trim().length > 0;
+			})
+			.map(function (line) {
+				return line.match(/\"(.*)\":/)[1];
+			});
+
+		var sortedDependencies = Object.keys(JSON.parse(result).dependencies);
+		sortedDependencies.sort();
+		expect(dependencyNames).to.eql(sortedDependencies);
+	});
+
 	it('should work on emptiness', function() {
 		var result = JSON.parse(merge(
 			fixture('complete'),


### PR DESCRIPTION
This maintains synchronicity with npm --save which keeps keys in order.